### PR TITLE
Fix #23 - documentation for `.unstyled` class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
-# [1.3.7] - 2019-03-07
+# [1.3.8] - 2019-03-07
 
 ## Updated/fixes
 
 - fix `padding`s on `block-info-warning`
+
+## Misc
+
+- Added documentation for `unstyled` class
 
 # [1.3.6] - 2019-03-04
 

--- a/helpers.html
+++ b/helpers.html
@@ -170,6 +170,32 @@ section: fe-guidelines
     Applies standard <code>border-radius</code> to element (value defined with <code>$global-border-radius</code>).
   </div>
 </div>
+<div class="flex flex-spacebetween mb2 onmobile-flex-column">
+  <div class="w49">
+    <pre class=" language-markup"><code>&lt;ul <strong>class="unstyled"</strong>&gt;
+  …
+&lt;/ul&gt;
+</code></pre>
+  </div>
+  <div class="w49 flex-self-vcenter">
+    Removes styles for <code>ul</code> or <code>ol</code>. Example:
+    <div class="flex-autogrid">
+      <div class="flex-autogrid-item">
+        <ul>
+          <li>Normal</li>
+          <li>list</li>
+        </ul>
+      </div>
+      <div class="flex-autogrid-item">
+        <ul class="unstyled">
+          <li>unstyled</li>
+          <li>list</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Proton Design system, for all Proton Projects: https://design-system-beta.netlify.com/",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
BECAUSE. DOCUMENTATION. ALWAYS. 


Fixes #23 
