### PR TITLE
Feat #36 - update paths for images in CSS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+# [1.4.2] - 2019-03-11
+
+## Updated/fixes
+
+- use relative path for images (for webpack)
+- add documentation for variables
+- add missing `!default` on variables of the design system
+- updated `styles-pm` comments and “how to use design system” for variables
+- indentation fixes
+
+
 # [1.4.1] - 2019-03-08
 
 ## New

--- a/_sass/pm-styles/_pm-breadcrumb-domain.scss
+++ b/_sass/pm-styles/_pm-breadcrumb-domain.scss
@@ -9,7 +9,7 @@
   display: inline-block;
   width: 1.6rem;
   height: 1.6rem;
-  background: $pm-input-background url("/assets/img/shared/sprite-for-css-only.svg#css-greater") 0 0 no-repeat;
+  background: $pm-input-background url("#{$path-images}sprite-for-css-only.svg#css-greater") 0 0 no-repeat;
   background-size: 1.4rem;
   position: relative;
   top: 6px;

--- a/_sass/pm-styles/_pm-dropdown.scss
+++ b/_sass/pm-styles/_pm-dropdown.scss
@@ -1,5 +1,5 @@
 /* dropdown examples */
-$dropDown-width: 200px;
+$dropDown-width: 200px !default;
 .dropDown,
 .dropDown-leftArrow,
 .dropDown-rightArrow {

--- a/_sass/pm-styles/_pm-forms.scss
+++ b/_sass/pm-styles/_pm-forms.scss
@@ -30,7 +30,7 @@
   }
 
   &[type="search"] {
-    background: url("/assets/img/shared/sprite-for-css-only.svg#css-search") 6px 50% no-repeat;
+    background: url("#{$path-images}sprite-for-css-only.svg#css-search") 6px 50% no-repeat;
     background-size: 1.5rem;
     @extend .pl2;
     &::-webkit-search-cancel-button {
@@ -39,7 +39,7 @@
   }
 }
 select.pm-field {
-  background: $pm-input-background url("/assets/img/shared/sprite-for-css-only.svg#css-carret") calc(100% - 6px) 50% no-repeat;
+  background: $pm-input-background url("#{$path-images}sprite-for-css-only.svg#css-carret") calc(100% - 6px) 50% no-repeat;
   background-size: 1.5rem;
   padding-left: 1em;
   padding-right: 25px;

--- a/_sass/pm-styles/_pm-modal.scss
+++ b/_sass/pm-styles/_pm-modal.scss
@@ -2,10 +2,10 @@
  * Modals
  */
 /* overlay covers everything */
-$modal-width: 50%;
-$modal-min-width: 42em;
+$modal-width: 50% !default;
+$modal-min-width: 42em !default;
 
-$modal-smaller-width: 22em;
+$modal-smaller-width: 22em !default;
 
 .pm-modalOverlay {
   position: fixed;

--- a/_sass/reusable-components/_design-system-config.scss
+++ b/_sass/reusable-components/_design-system-config.scss
@@ -1,8 +1,4 @@
-// Compass import, if necessary
-//@import "compass/css3";
- 
-
-// Sass variables: adapt them to your designs
+// Sass variables: adapt them to your designs globally
 
 // base size for text
 $base-font             : 14 !default; // if "14" then 1em = 14px
@@ -14,27 +10,27 @@ $font-family           : -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxyg
 
 
 // project colors
-$pm-global-grey     : #262a33;
-$pm-global-altgrey  : #3c414e;
-$pm-global-light    : #F6F7FA;
-$pm-global-border   : #DDE6EC;
-$pm-global-muted    : #eeeff1;
-$pm-global-success  : #5db039;
-$pm-global-warning  : #EC5858;
-$pm-global-attention: #EAC819;
-$pm-blue            : #657ee4;
-$pm-blue-dark       : #526ee0;
-$pm-blue-light      : #788EE8;
+$pm-global-grey        : #262a33;
+$pm-global-altgrey     : #3c414e;
+$pm-global-light       : #f6f7fa;
+$pm-global-border      : #dde6ec;
+$pm-global-muted       : #eeeff1;
+$pm-global-success     : #5db039;
+$pm-global-warning     : #ec5858;
+$pm-global-attention   : #eac819;
+$pm-blue               : #657ee4;
+$pm-blue-dark          : #526ee0;
+$pm-blue-light         : #788ee8;
 
-$white              : #fff;
-$black              : #000;
+$white                 : #fff;
+$black                 : #000;
 
-$pv-green           : #4DA358;
-$pv-green-dark      : #3E8447;
-$pv-green-light     : #5FB364;
+$pv-green              : #4da358;
+$pv-green-dark         : #3e8447;
+$pv-green-light        : #5fb364;
 
 // not approved colors
-$pm-input-background: #fcfdff;
+$pm-input-background   : #fcfdff;
 
 // colors
 $color-links           : $pm-blue;
@@ -91,6 +87,9 @@ $root-default-font-size: 16 !default;
 $use-reset-button      : true !default;
 $use-old-ie-fallbacks  : true !default;
 
+// default config for webpack, can be overriden by "global config" in styles-pm.scss
+$path-images           : '../../assets/img/shared/' !default;
+
 
 // Sass functions: don’t touch if you are not sure ;)
 
@@ -115,7 +114,7 @@ $use-old-ie-fallbacks  : true !default;
 // calculated via https://rocssti.net/en/builder-css
 // based on http://soqr.fr/vertical-rhythm/ thanks @goetter & @eQRoeil
 
-@function line-height ($font-size, $base-height, $base-font, $type-vr){
+@function line-height ($font-size, $base-height, $base-font, $type-vr) {
 
   $coef: ceil(1 / ($base-height * $base-font / $font-size));
   $height: ($base-font * $base-height / $font-size) ;
@@ -125,7 +124,7 @@ $use-old-ie-fallbacks  : true !default;
 }
 
 
-@function margin-em ($font-size, $base-height, $base-font, $type-vr){
+@function margin-em ($font-size, $base-height, $base-font, $type-vr) {
 
   $coef: ceil(1 / ($base-height * $base-font / $font-size));
   $other_coef: ceil($base-height * $base-font / $font-size);

--- a/assets/css/styles-pm.scss
+++ b/assets/css/styles-pm.scss
@@ -23,7 +23,7 @@
  * RTL = Right To Left =>
  * to adapt a website in a language that is written from right to left
  * designed for multilingual websites with LTR et RTL
- * set $rtl_option to true in design-system-config
+ * set $rtl_option to true
  *
  *
  * summary
@@ -34,6 +34,13 @@
  * 
  * 
  */
+
+/*
+ * global variables for this case
+ * if you need to override values in design-system-config or another
+ * do it here and NOT in partials (which might be updated)
+ */
+$path-images  : '../img/shared/';
 
 
 @import "reusable-components/design-system-config";

--- a/how-to-use-design-system.html
+++ b/how-to-use-design-system.html
@@ -49,3 +49,7 @@ section: fe-guidelines
   <li>Images used by the Design System CSS and which could <strong>be re-used on other projects</strong> are in the folder <code>/assets/img/shared</code>.</li>
   <li>Images <strong>only used by the Design System website</strong> are in the folder <code>/assets/img/design-system-website</code>.</li>
 </ol>
+
+<h2>Overwriting variables</h2>
+
+<p>If you need (for your project) to set up different values than the default one of the design system, do overwrite variables in <code>styles-pm.scss</code>, <strong class="uppercase">not</strong> in Sass partials.</p>

--- a/icons.html
+++ b/icons.html
@@ -233,4 +233,6 @@ subsection: icons
   {% endfor %}
   </div>
 
+  <p>Please do use the Sass variable <code>$path-images</code> when using them.</p>
+
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Proton Design system, for all Proton Projects: https://design-system-beta.netlify.com/",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Short description of what this resolves:

Issues for WebPack builds, and better reusability

## Changes proposed in this pull request:

- use relative path for images (for webpack)
- add documentation for variables
- add missing `!default` on variables of the design system partials
- updated `styles-pm` comments and “how to use design system” for variables
- indentation fixes

Fixes #36 
