### PR TITLE
Feat #34 - stroke width bigger for icons

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+# [1.4.4] - 2019-03-15
+
+## New
+
+- added class `dash2x` to make path bigger on SVGs
+
 # [1.4.3] - 2019-03-12
 
 ## New

--- a/_sass/reusable-components/_design-system-links-icons.scss
+++ b/_sass/reusable-components/_design-system-links-icons.scss
@@ -71,6 +71,11 @@ a[href^="mailto:"] {
   height: 50%;
 }
 
-
+.path2x {
+  stroke-width: 1px;
+  &.fill-global-light {
+    stroke: $pm-global-light;   
+  }
+}
 
 

--- a/icons.html
+++ b/icons.html
@@ -242,6 +242,38 @@ subsection: icons
     </div>
   </div>
 
+  <p>Bigger shape examples: </p>
+  <div class="flex flex-spacebetween flex-item-end mb2 onmobile-flex-column onmobile-flex-item-nostretch ">
+    <div class="w49 aligncenter">
+      <span class="inline-flex bg-global-success rounded50 p0-25">
+        <svg viewBox="0 0 16 16" class="icon-25p mauto path2x fill-global-light" aria-hidden="true" role="img" focusable="false">
+          <use xlink:href="#shape-on"></use>
+        </svg>
+      </span>
+      <pre class=" language-markup"><code>&lt;span class="inline-flex bg-global-success rounded50 p0-25"&gt;
+  &lt;svg viewBox="0 0 16 16" class="icon-25p mauto <strong>path2x</strong> fill-global-light" aria-hidden="true" role="img" focusable="false"&gt;
+    &lt;use xlink:href="#shape-on"&gt;&lt;/use&gt;
+  &lt;/svg&gt;
+&lt;/span&gt;
+</code></pre>
+    </div>
+    <div class="w49 aligncenter ">
+      <span class="inline-flex bg-global-attention rounded50 p0-25">
+        <svg viewBox="0 0 16 16" class="icon-25p m0-5 path2x fill-global-light" aria-hidden="true" role="img" focusable="false">
+          <use xlink:href="#shape-off"></use>
+        </svg>
+      </span>
+
+      <pre class=" language-markup"><code>&lt;span class="inline-flex bg-global-attention rounded50 p0-25"&gt;
+  &lt;svg viewBox="0 0 16 16" class="icon-25p <strong>m0-5 path2x</strong> fill-global-light" aria-hidden="true" role="img" focusable="false"&gt;
+    &lt;use xlink:href="#shape-off"&gt;&lt;/use&gt;
+  &lt;/svg&gt;
+&lt;/span&gt;
+</code></pre>
+    </div>
+  </div>
+  
+
 </div>
 
 


### PR DESCRIPTION
SVG 4 ever !!!! (works even on IE11)

Look at the doc here: https://design-system-beta.netlify.com/icons/#sizes-colors

Basically, we can do whatever we want.

Fixes #34 
