### PR TITLE
Feat #44 - gradient for navigation scrolling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,7 +63,7 @@
 
             <div class="flex no-scroll flex-column flex-nowrap js-sidebar-container">
 
-              <nav class="navigation flex-item-fluid mb1 scroll-if-needed js-navigation">
+              <nav class="navigation flex-item-fluid scroll-if-needed js-navigation">
               
                 <p class="navigation__title mb0 mt0 js-expandmore" data-hideshow-prefix-class="animated">Design</p>
                 <ul class="navigation__list unstyled js-to_expand{% if page.section == 'design' %} is-opened{% endif %}">

--- a/_sass/design-system-website/_global-structure.scss
+++ b/_sass/design-system-website/_global-structure.scss
@@ -107,7 +107,7 @@ body {
   right: 0;
   left: 0;
   height: 2em;
-  background: linear-gradient(to top, #000 0, rgba(0, 0, 0, 0) 2em);
+  background: linear-gradient(to top, rgba(0, 0, 0, .4) 0, rgba(0, 0, 0, 0) 2em);
 }
 
 .navigation__link:focus,


### PR DESCRIPTION
## Short description of what this resolves:

Add gradient at the bottom of the navigation on the left when it is scrollable.

## Changes proposed in this pull request:

- This toggles a class `has-scroll-inside-navigation` on `js-sidebar-container`.
- When this class is activated, it adds a `::before` element on `progressBar-container` with adds the gradient on the top of previous element `nav`.
- this gradient is toggled when the user resizes his windows, when the page is loaded, and when there is a click on the expanding sections (with Mutation Observer). If the user scrolls to the end of this div, the gradient is removed.

Fixes #44 

![image](https://user-images.githubusercontent.com/2578321/54933050-377b0b00-4f1c-11e9-8ea5-78db4b902fa5.png)

