### PR TITLE
Feat #81 - error in forms

### DIFF
--- a/_sass/pm-styles/_pm-forms.scss
+++ b/_sass/pm-styles/_pm-forms.scss
@@ -15,7 +15,7 @@
     background-color: $white;
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.16);
   }
-  &.ng-invalid:not(:focus) {
+  &[aria-invalid="true"]:not(:focus) {
     border-color: $pm-global-warning;
   }
   &.ng-valid:not(:focus) {
@@ -68,7 +68,18 @@ select.pm-field {
   }
 }
 
+/* errors */
+.error-zone {
+  transition: transform .15s linear;
+  transform: scaleY(1);
+  transform-origin: top center;
+  &:empty {
+    transform: scaleY(0);
+  }
+}
 
+
+/* sizes */
 .pm-field--small {
   padding: em(2) em(16);  // design want 26px height (actually 27 to avoid .5px)
 }

--- a/forms.html
+++ b/forms.html
@@ -46,9 +46,10 @@ section: design
     <label for="id_field4" class="pm-label">
         Error Form
     </label>
-    <span>
-        <input type="text" id="id_field4" class="pm-field ng-invalid" value="This is a mistake" />
-    </span>
+    <div>
+        <input type="text" id="id_field4" class="pm-field" aria-invalid="true" value="This is a mistake" aria-describedby="error1" />
+        <div class="color-global-warning error-zone" id="error1">There is an error. There is an error.<br> There is an error. There is an error. </div>
+    </div>
 </div>
 <div class="flex flex-nowrap onmobile-flex-column mb1">
     <label for="id_field5" class="pm-label">
@@ -78,6 +79,15 @@ section: design
     </span>
 </div>
 <div class="flex flex-nowrap onmobile-flex-column mb1">
+    <label for="id_textarea2" class="pm-label">
+        Another zone
+    </label>
+    <div>
+        <textarea name="textaread2" id="id_textarea2" class="pm-field" aria-invalid="true" cols="30" rows="5" aria-describedby="area_error_id"></textarea>
+        <div class="color-global-warning error-zone" id="area_error_id">There is an error. </div>
+    </div>
+</div>
+<div class="flex flex-nowrap onmobile-flex-column mb1">
     <label for="id_field6" class="pm-label">
         A select
     </label>
@@ -86,6 +96,18 @@ section: design
             <option value="">An loooooooooooooooooon option</option>
             <option value="">Another option</option>
         </select>
+    </span>
+</div>
+<div class="flex flex-nowrap onmobile-flex-column mb1">
+    <label for="id_field6b" class="pm-label">
+        Another select
+    </label>
+    <span>
+        <select id="id_field6b" class="pm-field" aria-invalid="true" id="area_select_id">
+            <option value="">An option</option>
+            <option value="">Another option</option>
+        </select>
+        <div class="color-global-warning error-zone" id="area_select_id">There is an error. </div>
     </span>
 </div>
 <div class="flex flex-nowrap onmobile-flex-column mb1">


### PR DESCRIPTION
- rely on `aria-invalid="true"` for redborder on input (better for a11y)
- linked via `aria-describedby` to error div
- transitionned to appear as softly as possible

http://recordit.co/IAr9GHHP2B

Fixes #81 
