### PR TITLE
Feat #110 - search image as content image

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+# [1.6.x] - 2019-05-08
+
+## Updated/fixes
+
+- set search image as content image
+- removed CSS variable for it
+- fix RTL adaptation
+- updated blue and light theme
+- updated theme config
+- updated documentation
+
+
 # [1.6.4] - 2019-05-07
 
 ## New

--- a/_headers
+++ b/_headers
@@ -3,14 +3,14 @@
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: "upgrade-insecure-requests;  block-all-mixed-content; default-src 'none' ;  script-src 'self' *.cloudfront.net ; style-src 'self' *.cloudfront.net 'sha256-axJAleRYmgE2popQk1h5l7p2/lhfnH8jD0wqIpOTmDc=' 'sha256-BSotIw2cpD4FO1E2ZzaNY7y3BwHroOxKhlUxKNR9b6I=' 'sha256-Rr9yQevh5CrnyfQ/SxgQb9Bw1cuGHgnVTBrv4hJsvFs=' 'sha256-twjyZjal+Oc8CUkLCKUx81bCYteKynOh/Zwy1yChfL8=' 'sha256-CQWw9bKBuACYHQKsESp7mzv8LocqAICcNVC1f9KSoZw=' 'sha256-6Na8PnO5MDPbvsoBmLXVql0HhH/C5JQK0mmwtfpTSB0=' 'sha256-owgmuL++JGIg3d9kA0NQ78g/Y6Ki1AOQhoP3UNhnFuc=' ; img-src 'self' *.cloudfront.net; font-src 'self';  connect-src 'self' ; child-src 'self' ; frame-src 'self' ; frame-ancestors 'self' ; manifest-src 'self' ; worker-src 'self' ; base-uri 'self' ; form-action 'self' ; "
+  Content-Security-Policy: "upgrade-insecure-requests;  block-all-mixed-content; default-src 'none' ;  script-src 'self' *.cloudfront.net ; style-src 'self' *.cloudfront.net 'sha256-axJAleRYmgE2popQk1h5l7p2/lhfnH8jD0wqIpOTmDc=' 'sha256-BSotIw2cpD4FO1E2ZzaNY7y3BwHroOxKhlUxKNR9b6I=' 'sha256-e13yk9DRmm9ZhxY0Lre4wEjaDvbGAzKW1ZRsfPTGjKE=' 'sha256-VsonfmZsSQn7VmV5LIiM1yEvDv2Z5uyF0Pxnc5oT/P4=' 'sha256-CQWw9bKBuACYHQKsESp7mzv8LocqAICcNVC1f9KSoZw=' 'sha256-6Na8PnO5MDPbvsoBmLXVql0HhH/C5JQK0mmwtfpTSB0=' 'sha256-owgmuL++JGIg3d9kA0NQ78g/Y6Ki1AOQhoP3UNhnFuc=' ; img-src 'self' *.cloudfront.net; font-src 'self';  connect-src 'self' ; child-src 'self' ; frame-src 'self' ; frame-ancestors 'self' ; manifest-src 'self' ; worker-src 'self' ; base-uri 'self' ; form-action 'self' ; "
   Feature-Policy: "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr 'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'self'; fullscreen 'self'; payment 'none' ;"
 
 # 'sha256-axJAleRYmgE2popQk1h5l7p2/lhfnH8jD0wqIpOTmDc=' styles for SVG icons (Firefox bug)
 # 'sha256-BSotIw2cpD4FO1E2ZzaNY7y3BwHroOxKhlUxKNR9b6I=' styles for SVG image (Default composer, Firefox bug)
 # need to activate unsafe-inline for style for meter bar for IE11 => f***, we won't support it, removed
-# 'sha256-Rr9yQevh5CrnyfQ/SxgQb9Bw1cuGHgnVTBrv4hJsvFs=' for inline CSS for blue theme
-# 'sha256-twjyZjal+Oc8CUkLCKUx81bCYteKynOh/Zwy1yChfL8=' for inline CSS for light theme
+# 'sha256-e13yk9DRmm9ZhxY0Lre4wEjaDvbGAzKW1ZRsfPTGjKE=' for inline CSS for blue theme
+# 'sha256-VsonfmZsSQn7VmV5LIiM1yEvDv2Z5uyF0Pxnc5oT/P4=' for inline CSS for light theme
 
 # 'sha256-CQWw9bKBuACYHQKsESp7mzv8LocqAICcNVC1f9KSoZw=' styles for SVG image for blue theme (Firefox bug)
 # 'sha256-6Na8PnO5MDPbvsoBmLXVql0HhH/C5JQK0mmwtfpTSB0=' styles for SVG image for dark theme (Firefox bug)

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,8 +12,14 @@
                 <span class="sr-only">Search (not implemented)</span>
                 <input type="search" id="global_search" placeholder="Search (not implemented)" class="pm-field w100 searchbox-field ">
             </label>
+            <button type="button" class="searchbox-search-button flex" title="Search (not implemented)">
+              <svg viewBox="0 0 16 16" class="fill-white mauto searchbox-search-button-icon" role="img" focusable="false" aria-hidden="true">
+                <use xlink:href="#shape-search"></use>
+              </svg>
+              <span class="sr-only">Search (not implemented)</span>
+            </button>
             <button type="button" class="searchbox-advanced-search-button" title="open advanced search (not implemented)">
-              <svg viewBox="0 0 16 16" class="icon-16p fill-white" role="img" focusable="false">
+              <svg viewBox="0 0 16 16" class="icon-16p fill-white" role="img" focusable="false" aria-hidden="true">
                 <use xlink:href="#shape-caret"></use>
               </svg>
               <span class="sr-only">open advanced search (not implemented)</span>

--- a/_sass/pm-styles/_pm-blue-theme.scss
+++ b/_sass/pm-styles/_pm-blue-theme.scss
@@ -12,6 +12,5 @@ $color-nav-link: $white;
 $color-nav-active: $white;
 $color-standard-text: $white;
 $boxshadow-main: none;
-$img-searchbox-path: url(#{$path-images}sprite-for-css-only.svg#css-search-white);
 
 @import "./pm-theme-config";

--- a/_sass/pm-styles/_pm-header-searchbar.scss
+++ b/_sass/pm-styles/_pm-header-searchbar.scss
@@ -7,14 +7,23 @@
 .searchbox-field[type="search"] {
   height: 4rem;
   background-color: var(--bgcolor-searchbox-field, $black);
-  background-image: var(--img-searchbox-path, url(#{$path-images}sprite-for-css-only.svg#css-search-white));
-  background-position: 15px 50%;
+  background-image: none;
   border-color: var(--main-bg-color, $black);
   box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.2);
   background-size: 2rem;
-  padding-left: calc(15px + 2rem + 15px);
+  padding-left: calc(2em + 2rem);
   padding-right: 4rem;
   color: var(--color-standard-text, $white);
+}
+.searchbox-search-button {
+  position: absolute;
+  left: 1em;
+  top: 0;
+  bottom: 0;
+  & > .searchbox-search-button-icon {
+    width: 2.2rem;
+    fill: var(--fillcolor-icons, $white);
+  }
 }
 .searchbox-advanced-search-button {
   position: absolute;
@@ -23,18 +32,21 @@
   bottom: 0;
   padding: 0 1rem;
   & > svg {
-    fill: var(--fillcolor-icons, $white)
+    fill: var(--fillcolor-icons, $white);
   }
 }
 
 @if $rtl-option == true {
   [dir="rtl"] {
     .searchbox-field[type="search"] { 
-      background-image: url("#{$path-images}sprite-for-css-only.svg#css-search-white-rtl");
-      background-position: calc(100% - 15px) 50%; 
-      padding-right: calc(15px + 2rem + 15px);
+      padding-right: calc(2em + 2rem);
       padding-left: 4rem;
+      background-image: none;
       background-size: 2rem;
+    }
+    .searchbox-search-button {
+      right: 1em;
+      left: auto;
     }
     .searchbox-advanced-search-button {
       right: auto;

--- a/_sass/pm-styles/_pm-light-theme.scss
+++ b/_sass/pm-styles/_pm-light-theme.scss
@@ -12,6 +12,5 @@ $color-nav-link: $pm-global-grey;
 $color-nav-active: $pm-blue-dark;
 $color-standard-text: $pm-global-grey;
 $boxshadow-main: 0 0 15px 0 rgba(0, 0, 0, 0.1);
-$img-searchbox-path: url(#{$path-images}sprite-for-css-only.svg#css-search-black);
 
 @import "./pm-theme-config";

--- a/_sass/pm-styles/_pm-theme-config.scss
+++ b/_sass/pm-styles/_pm-theme-config.scss
@@ -11,5 +11,4 @@
   --color-nav-active: #{$color-nav-active};
   --color-standard-text: #{$color-standard-text};
   --boxshadow-main: #{$boxshadow-main};
-  --img-searchbox-path: #{$img-searchbox-path};
 }   

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1023,8 +1023,7 @@ function themePreview( e ) {
     css += '  --color-nav-active: ' + values.colorNavActive + ';' + "\n";
     css += '  --color-standard-text: ' + values.colorStandardText + ';' + "\n";
 
-    css += '  --boxshadow-main: ' + values.boxshadowMain + ';' + "\n";
-    css += '  --img-searchbox-path: ' + values.imgSearchbox + '; }' + "\n";
+    css += '  --boxshadow-main: ' + values.boxshadowMain + '; }' + "\n";
 
     css_mini += ':root{';
     css_mini += '--main-bg-color:' + values.mainBgColor + ';';
@@ -1042,8 +1041,7 @@ function themePreview( e ) {
     css_mini += '--color-nav-active:' + values.colorNavActive + ';';
     css_mini += '--color-standard-text:' + values.colorStandardText + ';';
 
-    css_mini += '--boxshadow-main:' + values.boxshadowMain + ';';
-    css_mini += '--img-searchbox-path:' + values.imgSearchbox + ';}';
+    css_mini += '--boxshadow-main:' + values.boxshadowMain + ';}';
 
     //console.log(css_mini);
 

--- a/sass-variables.html
+++ b/sass-variables.html
@@ -64,7 +64,6 @@ subsection: sass-variables
   <li class="mb0-5"><code>--color-nav-active</code>: color used for navigation links when active</li>
   <li class="mb0-5"><code>--color-standard-text</code>: color used for text</li>
   <li class="mb0-5"><code>--boxshadow-main</code>: used to apply a box shadow on main content (used for light theme for example)</li>
-  <li class="mb0-5"><code>--img-searchbox-path</code>: the path for search icon in search box.</li>
 </ul>
 
 <p>Updating these custom properties allows to create simple themes without surcharging all the CSS stuff.</p>

--- a/themes.html
+++ b/themes.html
@@ -33,8 +33,7 @@ section: design
     data-color-nav-active="#fff"
     data-color-standard-text="#fff"
 
-    data-boxshadow-main="none"
-    data-img-searchbox="url(/assets/img/shared/sprite-for-css-only.svg#css-search-white)">
+    data-boxshadow-main="none">
     <img src="/assets/img/pm-images/theme-blue.svg" alt="Activate blue theme">
 </button>
 
@@ -58,8 +57,7 @@ section: design
     data-color-nav-active="#526ee0"
     data-color-standard-text="#262a33"
 
-    data-boxshadow-main="0 0 15px 0 rgba(0, 0, 0, 0.1)"
-    data-img-searchbox="url(/assets/img/shared/sprite-for-css-only.svg#css-search-black)">
+    data-boxshadow-main="0 0 15px 0 rgba(0, 0, 0, 0.1)">
     <img src="/assets/img/pm-images/theme-light.svg" alt="Activate light theme">
 </button>
 


### PR DESCRIPTION
## Short description of what this resolves:

Remove search image from background image of top search bar

## Changes proposed in this pull request:

- set search image as content image
- removed CSS variable for it
- fixed RTL adaptation
- update blue and light theme
- updated theme config
- updated documentation

Fixes #110 
