### PR TITLE
Fix #124 - Group button with expand

### DIFF
--- a/_sass/pm-styles/_pm-buttons.scss
+++ b/_sass/pm-styles/_pm-buttons.scss
@@ -92,7 +92,7 @@
   &[disabled] {
     background-color: $pm-global-muted;
     color: rgba( $pm-global-grey, .3 );
-    border: 1px solid $pm-global-border;
+    border-color: $pm-global-border;
     pointer-events: none;
   }
   /* just to cancel examples  */
@@ -111,12 +111,12 @@
   &:focus-within,
   &.is-hover {
     box-shadow: 0 0 em(5) 0 rgba(0, 0, 0, 0.2);
-    border: 1px solid $pm-blue-dark;
+    border-color: $pm-blue-dark;
     color: $pm-blue-dark;
   }
   &:active,
   &.is-active {
-    border: 1px solid $pm-blue-dark;
+    border-color: $pm-blue-dark;
     color: $pm-blue-dark;
     background: radial-gradient(closest-side, $white, $pm-global-border 90%);
     box-shadow: none;
@@ -124,13 +124,13 @@
   &[disabled] {
     background-color: $pm-global-muted;
     color: rgba( $pm-global-grey, .3 );
-    border: 1px solid $pm-global-border;
+    border-color: $pm-global-border;
     pointer-events: none;
   }
 }
 
 .pm-button-blueborder-dark {
-  border: 1px solid $pm-blue-light;
+  border-color: $pm-blue-light;
   color: $pm-blue-light;
   background-color: $pm-global-grey;
 
@@ -141,7 +141,7 @@
   &:active,
   &.is-active {
     background-color: rgba(0, 0, 0, 0.2);
-    border: 1px solid $pm-blue-dark;
+    border-color: $pm-blue-light;
     color: $pm-blue-dark;
   }
   &:active,
@@ -151,7 +151,7 @@
   &[disabled] {
     background-color: $pm-global-muted;
     color: rgba( $pm-global-grey, .3 );
-    border: 1px solid $pm-global-border;
+    border-color: $pm-global-border;
     pointer-events: none;
   }
 }
@@ -177,7 +177,7 @@
   &[disabled] {
     background-color: $pm-global-muted;
     color: rgba( $pm-global-grey, .3 );
-    border: 1px solid $pm-global-border;
+    border-color: $pm-global-border;
     pointer-events: none;
   }
   /* just to cancel examples  */
@@ -196,12 +196,12 @@
   &:focus-within,
   &.is-hover {
     box-shadow: 0 0 em(5) 0 rgba(0, 0, 0, 0.2);
-    border: 1px solid $pv-green-dark;
+    border-color: $pv-green-dark;
     color: $pv-green-dark;
   }
   &:active,
   &.is-active {
-    border: 1px solid $pv-green-dark;
+    border-color: $pv-green-dark;
     color: $pv-green-dark;
     background: radial-gradient(closest-side, $white, $pm-global-border 90%);
     box-shadow: none;
@@ -226,7 +226,7 @@
   &:active,
   &.is-active {
     background-color: rgba(0, 0, 0, 0.2);
-    border: 1px solid $pv-green-dark;
+    border-color: $pv-green-dark;
     color: $pv-green-dark;
   }
   &:active,
@@ -236,7 +236,7 @@
   &[disabled] {
     background-color: $pm-global-muted;
     color: rgba( $pm-global-grey, .3 );
-    border: 1px solid $pm-global-border;
+    border-color: $pm-global-border;
     pointer-events: none;
   }
 }
@@ -306,6 +306,7 @@
   color: $color-links;
   border-width: 0;
   box-shadow: none;
+  background-color: transparent; // to avoid heriting from other classes
   &:focus,
   &:hover,
   &:active {

--- a/_sass/pm-styles/_pm-buttons.scss
+++ b/_sass/pm-styles/_pm-buttons.scss
@@ -8,7 +8,11 @@
   padding: em(5) em(16) em(6); // design want 34px height
   border-style: solid;
   border-width: 1px;
+  & > button { // this is for drop down buttons
+    color: inherit;
+  }
 }
+
 
 .pm-button {
   border-color: $pm-global-border;
@@ -74,6 +78,7 @@
 
   &:focus,
   &:hover,
+  &:focus-within,
   &.is-hover {
     box-shadow: 0 0 em(5) 0 rgba(0, 0, 0, 0.2);
     background: $pm-blue-dark;
@@ -103,6 +108,7 @@
 
   &:focus,
   &:hover,
+  &:focus-within,
   &.is-hover {
     box-shadow: 0 0 em(5) 0 rgba(0, 0, 0, 0.2);
     border: 1px solid $pm-blue-dark;
@@ -130,6 +136,7 @@
 
   &:focus,
   &:hover,
+  &:focus-within,
   &.is-hover,
   &:active,
   &.is-active {
@@ -156,6 +163,7 @@
 
   &:focus,
   &:hover,
+  &:focus-within,
   &.is-hover {
     box-shadow: 0 0 em(5) 0 rgba(0, 0, 0, 0.2);
     background: $pv-green-dark;
@@ -185,6 +193,7 @@
 
   &:focus,
   &:hover,
+  &:focus-within,
   &.is-hover {
     box-shadow: 0 0 em(5) 0 rgba(0, 0, 0, 0.2);
     border: 1px solid $pv-green-dark;
@@ -212,6 +221,7 @@
 
   &:focus,
   &:hover,
+  &:focus-within,
   &.is-hover,
   &:active,
   &.is-active {
@@ -230,6 +240,8 @@
     pointer-events: none;
   }
 }
+
+
 
 /* modifiers */
 .pm-button--large {
@@ -263,22 +275,22 @@
   position: relative;
   z-index: 10;
 }
-.pm-group-buttons > .pm-group-button:not(.pagination-expand):first-of-type {
+.pm-group-buttons > .pm-group-button:first-child {
   border-radius: $global-border-radius 0 0 $global-border-radius;
   border-left-width: 1px;
 }
-.pm-group-buttons > .pm-group-button:not(.pagination-expand):last-of-type {
+.pm-group-buttons > .pm-group-button:last-child {
   border-radius: 0 $global-border-radius $global-border-radius 0;
 }
 
 @if $rtl-option == true {
   [dir="rtl"] {
-    .pm-group-buttons > .pm-group-button:not(.pagination-expand):first-of-type {
+    .pm-group-buttons > .pm-group-button:not(.pagination-expand):first-child {
       border-radius: 0 $global-border-radius $global-border-radius 0;
       border-right-width: 1px;
       border-left-width: 0;
     }
-    .pm-group-buttons > .pm-group-button:not(.pagination-expand):last-of-type {
+    .pm-group-buttons > .pm-group-button:not(.pagination-expand):last-child {
       border-radius: $global-border-radius 0 0 $global-border-radius;
       border-left-width: 1px;
     }

--- a/_sass/pm-styles/_pm-dropdown.scss
+++ b/_sass/pm-styles/_pm-dropdown.scss
@@ -1,6 +1,6 @@
 /* dropdown examples */
 $dropDown-width: 200px !default;
-$dropDown-pagination-width: 8em !default;
+$dropDown-narrow-width: 8em !default;
 
 .dropDown,
 .dropDown-leftArrow,
@@ -25,11 +25,12 @@ $dropDown-pagination-width: 8em !default;
   background: $white;
   border-radius: $global-border-radius;
   box-shadow: 0 0 16px 3px rgba(0, 0, 0, 0.16);
+  color: $pm-global-grey;
 }
 
-.dropDown-content--pagination {
-  left: calc(50% - #{$dropDown-pagination-width/2});
-  width: $dropDown-pagination-width;
+.dropDown-content--narrow {
+  left: calc(50% - #{$dropDown-narrow-width/2});
+  width: $dropDown-narrow-width;
   padding: 0 1rem;
 }
 
@@ -107,6 +108,9 @@ $dropDown-pagination-width: 8em !default;
 }
 
 /* pagination caret */
-.pagination-expand-button[aria-expanded="true"] > .pagination-expand-caret {
+.expand-caret {
+  fill: currentColor;
+}
+.dropDown [aria-expanded="true"] .expand-caret {
   @extend .rotateX-180;
 }

--- a/_sass/pm-styles/_pm-dropdown.scss
+++ b/_sass/pm-styles/_pm-dropdown.scss
@@ -2,9 +2,7 @@
 $dropDown-width: 200px !default;
 $dropDown-narrow-width: 8em !default;
 
-.dropDown,
-.dropDown-leftArrow,
-.dropDown-rightArrow {
+.dropDown {
   @extend .relative;
 }
 .dropDown-content {
@@ -44,21 +42,21 @@ $dropDown-narrow-width: 8em !default;
 }
 
 /* position of dropDown variations */
-.dropDown-leftArrow .dropDown-content {
+.dropDown--leftArrow .dropDown-content {
   left: 0;
 }
-.dropDown-rightArrow .dropDown-content {
+.dropDown--rightArrow .dropDown-content {
   left: auto;
   right: 0;
 }
 
 @if $rtl-option == true {
   [dir="rtl"] {
-    .dropDown-leftArrow .dropDown-content {
+    .dropDown--leftArrow .dropDown-content {
       right: 0;
       left: auto;
     }
-    .dropDown-rightArrow .dropDown-content {
+    .dropDown--rightArrow .dropDown-content {
       left: 0;
       right: auto;
     }
@@ -77,21 +75,21 @@ $dropDown-narrow-width: 8em !default;
   border-bottom: 1rem solid $white;
 }
 
-.dropDown-leftArrow .dropDown-content::before {
+.dropDown--leftArrow .dropDown-content::before {
   left: 1rem;
 }
-.dropDown-rightArrow .dropDown-content::before {
+.dropDown--rightArrow .dropDown-content::before {
   left: auto;
   right: 1rem;
 }
 
 @if $rtl-option == true {
   [dir="rtl"] {
-    .dropDown-leftArrow .dropDown-content::before {
+    .dropDown--leftArrow .dropDown-content::before {
       right: 1rem;
       left: auto;
     }
-    .dropDown-rightArrow .dropDown-content::before {
+    .dropDown--rightArrow .dropDown-content::before {
       right: auto;
       left: 1rem;
     }

--- a/_sass/pm-styles/_pm-wizard.scss
+++ b/_sass/pm-styles/_pm-wizard.scss
@@ -11,6 +11,10 @@ $size-current-pin: 16px !default;
   padding-left: 2px; // "optical" alignment, difficult to align text and circle ^^
 }
 
+.wizard-container--noTextDisplayed {
+  padding-top: 0;
+}
+
 .wizard {
   height: $height-wizard;
   display: flex;
@@ -91,4 +95,8 @@ $size-current-pin: 16px !default;
   &:not([aria-current]) .wizard-item-inner {
     @extend .invisible;
   }
+}
+
+.wizard-container--noTextDisplayed .wizard-item[aria-current="step"] .wizard-item-inner {
+  @extend .invisible;
 }

--- a/drop-down.html
+++ b/drop-down.html
@@ -10,8 +10,8 @@ section: design
 
 <div class="flex flex-spacebetween">
   <div>
-    <div class="dropDown-leftArrow inbl">
-      <button class="pm-button-blue inbl js-dropDown-button" aria-expanded="false" type="button">
+    <div class="dropDown-leftArrow pm-button-blue inbl">
+      <button class="increase-surface-click js-dropDown-button" aria-expanded="false" type="button">
         Left
       </button>
       <div class="js-dropDown-content dropDown-content" hidden>
@@ -22,8 +22,8 @@ section: design
     </div>
   </div>
   <div>
-    <div class="dropDown inbl">
-      <button class="pm-button-blue inbl js-dropDown-button" aria-expanded="false" type="button">
+    <div class="dropDown pm-button-blue inbl">
+      <button class="increase-surface-click js-dropDown-button" aria-expanded="false" type="button">
         Drop drown by default
       </button>
       <div class="js-dropDown-content dropDown-content" hidden>
@@ -34,8 +34,8 @@ section: design
     </div>
   </div>
   <div>
-    <div class="dropDown-rightArrow inbl">
-      <button class="pm-button-blue inbl js-dropDown-button" aria-expanded="true" type="button">
+    <div class="dropDown-rightArrow pm-button-blue inbl">
+      <button class="increase-surface-click js-dropDown-button" aria-expanded="true" type="button">
         Right
       </button>
       <div class="js-dropDown-content dropDown-content">
@@ -54,8 +54,8 @@ section: design
 
 <p>If the drop down has to be opened, just set <code>aria-expanded</code> to <code>true</code> on the button and remove <code>hidden</code> attribute on <code>.dropDown-content</code>.</p>
 
-<pre class=" language-markup"><code>&lt;div class="dropDown inbl"&gt;
-  &lt;button class="pm-button-blue" <strong>aria-expanded="false/true"</strong> type="button"&gt;
+<pre class=" language-markup"><code>&lt;div class="dropDown <strong>pm-button-blue</strong> inbl"&gt;
+  &lt;button class="<strong>increase-surface-click</strong>" <strong>aria-expanded="false/true"</strong> type="button"&gt;
     Drop Down button
   &lt;/button&gt;
   &lt;div <strong>class="dropDown-content" hidden</strong>&gt;
@@ -75,12 +75,14 @@ section: design
         </svg>
         <span class="sr-only">Previous page</span>
       </button>
-      <div class="relative pm-button pm-group-button pm-button--for-icon pagination-expand">
-        <button class="increase-surface-click js-dropDown-button pagination-expand-button" aria-expanded="false" type="button" title="Open pagination">
-          1 
-          <svg viewBox="0 0 16 16" class="icon-12p pagination-expand-caret" role="img" aria-hidden="true" focusable="false">
-            <use xlink:href="#shape-caret"></use>
-          </svg>
+      <div class="dropDown pm-button pm-group-button pm-button--for-icon">
+        <button class="increase-surface-click js-dropDown-button" aria-expanded="false" type="button" title="Open pagination">
+          <span class="mauto">
+            1
+            <svg viewBox="0 0 16 16" class="icon-12p expand-caret" role="img" aria-hidden="true" focusable="false">
+              <use xlink:href="#shape-caret"></use>
+            </svg>
+          </span>
         </button>
         <div class="js-dropDown-content unstyled dropDown-content dropDown-content--pagination" hidden>
           <ul class="unstyled mt0-5 mb0-5 aligncenter">
@@ -98,6 +100,16 @@ section: design
         <span class="sr-only">Next page</span>
       </button>
     </nav> 
+
+  <ul class="alignleft">
+    <li>For pagination, you may use <code>nav</code> tag.</li>
+    <li>For “icons only” buttons, please add <code>pm-button--for-icon</code> modifier, and do not forget to add text using <code>sr-only</code> class.</li>
+    <li>When there is text + caret icon in the button, please wrap them in a <code>span class="mauto"</code> (fixes vertical centering issues).</li>
+    <li>For the SVG caret icon, please add <code>expand-caret</code> class on it, this will manage the rotation when expanded/not expanded.</li>
+    <li></li>
+    <li></li>
+  </ul>
+
   </div>
   <div class="w49 aligncenter flex-self-vcenter">
     <pre class=" language-markup"><code>&lt;<strong>nav class="pm-group-buttons"</strong>&gt;
@@ -109,15 +121,17 @@ section: design
     <strong>&lt;span class="sr-only"&gt;Previous page&lt;/span&gt;</strong>
   &lt;/button&gt;
 
-  &lt;div <strong>class="relative pm-button pm-group-button pm-button--for-icon pagination-expand"</strong>&gt;
+  &lt;div <strong>class="dropDown pm-button pm-group-button pm-button--for-icon"</strong>&gt;
 
-    &lt;button <strong>class="increase-surface-click pagination-expand-button"</strong> aria-expanded="false/true" type="button" title="Open pagination"&gt;
-      1 
-      &lt;svg viewBox="0 0 16 16" <strong>class="icon-12p pagination-expand-caret"</strong> role="img" aria-hidden="true" focusable="false"&gt;
-        &lt;use xlink:href="#shape-caret"&gt;&lt;/use&gt;
-      &lt;/svg&gt;
+    &lt;button <strong>class="increase-surface-click"</strong> aria-expanded="false/true" type="button" title="Open pagination"&gt;
+      &lt;span class="mauto"&gt;
+        1 
+        &lt;svg viewBox="0 0 16 16" <strong>class="icon-12p expand-caret"</strong> role="img" aria-hidden="true" focusable="false"&gt;
+          &lt;use xlink:href="#shape-caret"&gt;&lt;/use&gt;
+        &lt;/svg&gt;
+      &lt;/span&gt;
     &lt;/button&gt;
-    &lt;div <strong>class="unstyled dropDown-content dropDown-content--pagination"</strong> hidden&gt;
+    &lt;div <strong>class="unstyled dropDown-content dropDown-content--narrow"</strong> hidden&gt;
       &lt;ul <strong>class="unstyled mt0-5 mb0-5 aligncenter"</strong>&gt;
         &lt;li class="dropDown-item"&gt;
           &lt;button class="w100 pt0-5 pb0-5" <strong>aria-current="page"</strong>&gt;1&lt;/button&gt;
@@ -146,6 +160,29 @@ section: design
 </div>
 
 
+<p>Other example</p>
+<nav class="pm-group-buttons">
+    <button class="pm-button pm-group-button">
+      Edit
+    </button>
+    <div class="dropDown pm-button pm-group-button pm-button--for-icon">
+      <button class="increase-surface-click flex js-dropDown-button" aria-expanded="false" type="button" title="Open pagination">
+        <span class="mauto">
+          Other
+          <svg viewBox="0 0 16 16" class="icon-12p expand-caret" role="img" aria-hidden="true" focusable="false">
+            <use xlink:href="#shape-caret"></use>
+          </svg>
+        </span>
+      </button>
+      <div class="js-dropDown-content unstyled dropDown-content dropDown-content--narrow" hidden>
+        <ul class="unstyled mt0-5 mb0-5 aligncenter">
+          <li class="dropDown-item"><button class="w100 pt0-5 pb0-5">Blah</button></li>
+          <li class="dropDown-item"><button class="w100 pt0-5 pb0-5">Blah</button></li>
+          <li class="dropDown-item"><button class="w100 pt0-5 pb0-5">Blah</button></li>
+        </ul>
+      </div>
+    </div>
+  </nav> 
 
 <h2 class="mt2">Drop down code (simple buttons)</h2>
 

--- a/drop-down.html
+++ b/drop-down.html
@@ -104,10 +104,8 @@ section: design
   <ul class="alignleft">
     <li>For pagination, you may use <code>nav</code> tag.</li>
     <li>For “icons only” buttons, please add <code>pm-button--for-icon</code> modifier, and do not forget to add text using <code>sr-only</code> class.</li>
-    <li>When there is text + caret icon in the button, please wrap them in a <code>span class="mauto"</code> (fixes vertical centering issues).</li>
     <li>For the SVG caret icon, please add <code>expand-caret</code> class on it, this will manage the rotation when expanded/not expanded.</li>
-    <li></li>
-    <li></li>
+    <li>Expand can contains links or buttons.</li>
   </ul>
 
   </div>
@@ -126,7 +124,7 @@ section: design
     &lt;button <strong>class="increase-surface-click"</strong> aria-expanded="false/true" type="button" title="Open pagination"&gt;
       &lt;span class="mauto"&gt;
         1 
-        &lt;svg viewBox="0 0 16 16" <strong>class="icon-12p expand-caret"</strong> role="img" aria-hidden="true" focusable="false"&gt;
+        &lt;svg viewBox="0 0 16 16" class="icon-12p <strong>expand-caret</strong>" role="img" aria-hidden="true" focusable="false"&gt;
           &lt;use xlink:href="#shape-caret"&gt;&lt;/use&gt;
         &lt;/svg&gt;
       &lt;/span&gt;
@@ -137,7 +135,7 @@ section: design
           &lt;button class="w100 pt0-5 pb0-5" <strong>aria-current="page"</strong>&gt;1&lt;/button&gt;
         &lt;/li&gt;
         &lt;li class="dropDown-item"&gt;
-          <strong>&lt;button class="w100 pt0-5 pb0-5"&gt;2&lt;/button&gt;</strong>
+          &lt;button class="w100 pt0-5 pb0-5"&gt;2&lt;/button&gt;
         &lt;/li&gt;
         &lt;li class="dropDown-item"&gt;
           &lt;button class="w100 pt0-5 pb0-5"&gt;3&lt;/button&gt;
@@ -160,8 +158,12 @@ section: design
 </div>
 
 
-<p>Other example</p>
-<nav class="pm-group-buttons">
+<h2 class="mt2" id="pagination-dropdown">Other example (edit button group)</h2>
+
+<div class="flex flex-spacebetween mb2 onmobile-flex-column">
+  <div class="w49 aligncenter">
+
+  <div class="pm-group-buttons">
     <button class="pm-button pm-group-button">
       Edit
     </button>
@@ -182,7 +184,66 @@ section: design
         </ul>
       </div>
     </div>
-  </nav> 
+  </div> 
+
+  <ul class="alignleft">
+    <li>If the drop down does not need to be wide, you may use <code>dropDown-content--narrow</code> modifier in order to make it… narrower (!).</li>
+    <li>Even if it is designed for “icons only” buttons, you may add <code>pm-button--for-icon</code> modifier in order to reduce the padding in these buttons.</li>
+    <li>When there is text + caret icon in the button, please add a <code>flex</code> class on the button, and wrap text + caret icon in a <code>span class="mauto"</code> (fixes vertical centering issues, CSS is great).</li>
+  </ul>
+
+  <p class="alignleft">Color may also be applied to buttons groups, the caret icon will take automatically the same color thanks to <code>fill: currentColor</code>:</p>
+
+  <div class="pm-group-buttons">
+      <button class="pm-button-blueborder pm-group-button">
+        Edit
+      </button>
+      <div class="dropDown pm-button-blueborder pm-group-button pm-button--for-icon">
+        <button class="increase-surface-click flex js-dropDown-button" aria-expanded="false" type="button" title="Open pagination">
+          <span class="mauto">
+            Other
+            <svg viewBox="0 0 16 16" class="icon-12p expand-caret" role="img" aria-hidden="true" focusable="false">
+              <use xlink:href="#shape-caret"></use>
+            </svg>
+          </span>
+        </button>
+        <div class="js-dropDown-content unstyled dropDown-content dropDown-content--narrow" hidden>
+          <ul class="unstyled mt0-5 mb0-5 aligncenter">
+            <li class="dropDown-item"><button class="w100 pt0-5 pb0-5">Blah</button></li>
+            <li class="dropDown-item"><button class="w100 pt0-5 pb0-5">Blah</button></li>
+            <li class="dropDown-item"><button class="w100 pt0-5 pb0-5">Blah</button></li>
+          </ul>
+        </div>
+      </div>
+    </div> 
+
+  </div>
+  <div class="w49 aligncenter flex-self-vcenter">
+    <pre class=" language-markup"><code>&lt;div class="pm-group-buttons"&gt;
+  &lt;button class="pm-button pm-group-button"&gt;
+    Edit
+  &lt;/button&gt;
+  &lt;div class="dropDown pm-button pm-group-button <strong>pm-button--for-icon</strong>"&gt;
+    &lt;button class="increase-surface-click flex js-dropDown-button" aria-expanded="false" type="button" title="Open pagination"&gt;
+      <strong>&lt;span class="mauto"&gt;</strong>
+        Other
+        &lt;svg viewBox="0 0 16 16" class="icon-12p expand-caret" role="img" aria-hidden="true" focusable="false"&gt;
+          &lt;use xlink:href="#shape-caret"&gt;&lt;/use&gt;
+        &lt;/svg&gt;
+      <strong>&lt;/span&gt;</strong>
+    &lt;/button&gt;
+    &lt;div class="js-dropDown-content unstyled dropDown-content <strong>dropDown-content--narrow</strong>" hidden&gt;
+      &lt;ul class="unstyled mt0-5 mb0-5 aligncenter"&gt;
+        &lt;li class="dropDown-item"&gt;&lt;button class="w100 pt0-5 pb0-5"&gt;Blah&lt;/button&gt;&lt;/li&gt;
+        …
+      &lt;/ul&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+</code></pre>
+  </div>
+</div>
+
 
 <h2 class="mt2">Drop down code (simple buttons)</h2>
 

--- a/drop-down.html
+++ b/drop-down.html
@@ -10,13 +10,13 @@ section: design
 
 <div class="flex flex-spacebetween">
   <div>
-    <div class="dropDown-leftArrow pm-button-blue inbl">
+    <div class="dropDown dropDown--leftArrow pm-button-blue inbl">
       <button class="increase-surface-click js-dropDown-button" aria-expanded="false" type="button">
         Left
       </button>
       <div class="js-dropDown-content dropDown-content" hidden>
           <div class="p1">
-            With <code>.dropDown-leftArrow</code> container class.
+            With <code>.dropDown--leftArrow</code> modifier class.
           </div>
       </div>
     </div>
@@ -34,13 +34,13 @@ section: design
     </div>
   </div>
   <div>
-    <div class="dropDown-rightArrow pm-button-blue inbl">
+    <div class="dropDown dropDown--rightArrow pm-button-blue inbl">
       <button class="increase-surface-click js-dropDown-button" aria-expanded="true" type="button">
         Right
       </button>
       <div class="js-dropDown-content dropDown-content">
           <div class="p1">
-            With <code>.dropDown-rightArrow</code> container class, already opened.
+            With <code>.dropDown--rightArrow</code> modifier class, already opened.
           </div>
       </div>
     </div>


### PR DESCRIPTION
## Short description of what this resolves:

- fixed bug on button group with 2 buttons `last/first-of-type`
- revamped drop down code (removed class, simplified, choosed classname more generic)
- also moved button classes to drop down and generalised `focus-within` 
- added group button example with colors
- fixed color management for caret
- updated leftArrow/rightArrow to modifier classes

Bonuses: 
- added modifier `wizard-container--noTextDisplayed` for wizard (hides the current step)
- fixed button--link modifier (background transparent
- documentation for drop down in button groups

Fixes #124 
