### PR TITLE
Fix #165 - dropDown-item border display

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@
 - added `w15` width helper
 - added icon `shape-contract-window` (for composer)
 
+## Updated/fixes
+
+- fixed `dropDown-item` border display
+
 
 # [1.6.18] - 2019-06-27
 

--- a/_sass/pm-styles/_pm-dropdown.scss
+++ b/_sass/pm-styles/_pm-dropdown.scss
@@ -133,11 +133,8 @@ $dropDown-narrow-width: 8em !default;
 
 
 /* border on items */
-.dropDown-item {
-  border-bottom: 1px solid $pm-global-border;
-  &:last-of-type {
-    border-bottom: 0;
-  }
+.dropDown-item + .dropDown-item {
+  border-top: 1px solid $pm-global-border;
 }
 
 /* pagination caret */


### PR DESCRIPTION
## Short description of what this resolves:

This fixes several issues:
- if an element is alone in the drop down
- if the last one has to be hidden.

## Changes proposed in this pull request:

- updated selector

Fixes #185 

![image](https://user-images.githubusercontent.com/2578321/60658386-53634680-9e53-11e9-89f4-c1e81683c586.png)

