### PR TITLE
Visible orderable row when modal is open

### DIFF
--- a/_sass/pm-styles/_pm-containers.scss
+++ b/_sass/pm-styles/_pm-containers.scss
@@ -24,6 +24,7 @@
 .row--orderable {
   z-index: 666; /* In case the modal is open */
   background-color: $white;
+  color: $pm-global-grey;
 }
 
 $block-info-border-width: 3px !default;

--- a/_sass/pm-styles/_pm-containers.scss
+++ b/_sass/pm-styles/_pm-containers.scss
@@ -21,6 +21,11 @@
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.16);
 }
 
+.row--orderable {
+  z-index: 666; /* In case the modal is open */
+  background-color: $white;
+}
+
 $block-info-border-width: 3px !default;
 [class*="block-info"] {
   padding: .5em 1.2em;


### PR DESCRIPTION
Currently the row that's being re-ordered is being hidden by open modal. Applying same z-index as the modal fixes the issue.

Required for https://github.com/ProtonMail/proton-contacts/issues/27