### PR TITLE
Add one image from Zeplin and modify logo class

### DIFF
--- a/_sass/design-system-website/_global-structure.scss
+++ b/_sass/design-system-website/_global-structure.scss
@@ -76,7 +76,7 @@ body {
 }
 .logo {
   width: 148px;
-  height: 36px;
+  height: 42px;
   margin-top: 5px;
 }
 .logo g {

--- a/assets/img/shared/generic-error.svg
+++ b/assets/img/shared/generic-error.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="232" height="277.641" viewBox="0 0 232 277.641">
+    <defs>
+        <style>
+            .cls-1{fill:none}.cls-2{clip-path:url(#clip-path)}.cls-3{fill:#f2f2f2}.cls-4{fill:#526ee0}.cls-5{fill:#657ee4}.cls-6{fill:#d0cde1}.cls-7{opacity:.1}.cls-8{fill:#9f616a}.cls-9{fill:#2f2e41}
+        </style>
+        <clipPath id="clip-path">
+            <path d="M0 0h232v277.641H0z" class="cls-1"/>
+        </clipPath>
+    </defs>
+    <g id="Component_75_1" class="cls-2" data-name="Component 75 – 1">
+        <circle id="Ellipse_847" cx="116" cy="116" r="116" class="cls-3" data-name="Ellipse 847" transform="translate(0 45.641)"/>
+        <g id="Group_3557" data-name="Group 3557" transform="translate(-638.711 -303.42)">
+            <g id="Group_3558" data-name="Group 3558" transform="translate(-30)">
+                <circle id="Ellipse_848" cx="36.408" cy="36.408" r="36.408" class="cls-4" data-name="Ellipse 848" transform="translate(742.718 478.936)"/>
+                <path id="Path_1779" d="M278.612 157.864a28.543 28.543 0 0 1-35.154-15.45l-39.464-88.63a38.218 38.218 0 0 1 19.367-50.458q1.663-.74 3.39-1.32A38.219 38.219 0 0 1 276.2 29.893l21.185 94.677a28.543 28.543 0 0 1-18.773 33.294z" class="cls-4" data-name="Path 1779" transform="translate(481.997 303.41)"/>
+                <ellipse id="Ellipse_850" cx="29.211" cy="29.211" class="cls-5" data-name="Ellipse 850" rx="29.211" ry="29.211" transform="translate(748.568 482.119)"/>
+                <path id="Path_1781" d="M279.172 150.922a26.189 26.189 0 0 1-32.255-14.176l-36.21-81.32a35.065 35.065 0 0 1 17.77-46.3q1.525-.679 3.11-1.211a35.067 35.067 0 0 1 45.373 25.587l19.44 86.873a26.189 26.189 0 0 1-17.228 30.547z" class="cls-5" data-name="Path 1781" transform="translate(477.967 299.905)"/>
+            </g>
+        </g>
+        <g id="Group_3556" data-name="Group 3556" transform="translate(-680.344 -156.673)">
+            <path id="Path_1824" d="M956.5 351.2l2.118-1.928s12.258-.477 13.21 3.38-5.418 3.5-5.418 3.5z" class="cls-6" data-name="Path 1824" transform="translate(-132.447 -55.885)"/>
+            <path id="Path_1825" d="M956.5 351.2l2.118-1.928s12.258-.477 13.21 3.38-5.418 3.5-5.418 3.5z" class="cls-7" data-name="Path 1825" transform="translate(-132.447 -55.885)"/>
+            <path id="Path_1826" d="M1005.994 365.115h2.283l7.077 2.283s4.794 7.99 2.511 8.9-2.968 1.37-5.708.685-3.881-.913-3.881-.913z" class="cls-5" data-name="Path 1826" transform="translate(-164.424 -66.132)"/>
+            <path id="Path_1827" d="M1011.056 316.31s-2.74-13.47-4.794-12.557 0 8.9 0 8.9l3.2 5.251z" class="cls-8" data-name="Path 1827" transform="translate(-164.007 -26.459)"/>
+            <path id="Path_1828" d="M1015.343 353.935a10.618 10.618 0 0 0 0-2.74c-.228-.685.228-2.055 0-2.283s-2.511-5.936-2.283-6.849a39.555 39.555 0 0 0 0-5.251l3.2-1.37 1.6 4.109s3.424 3.425 2.739 3.881.685 1.826.685 1.826l.685 2.055 1.826 3.425s.776 4.478-.754 5.663-7.698-2.466-7.698-2.466z" class="cls-4" data-name="Path 1828" transform="translate(-168.979 -46.962)"/>
+            <circle id="Ellipse_857" cx="11.293" cy="11.293" r="11.293" class="cls-9" data-name="Ellipse 857" transform="translate(821.88 269.239)"/>
+            <path id="Path_1829" d="M967.689 330.09s.457 7.534-.685 8.675 4.338 3.2 4.338 3.2h5.023s0-10.045 1.141-11.871-9.817-.004-9.817-.004z" class="cls-8" data-name="Path 1829" transform="translate(-139.132 -42.979)"/>
+            <path id="Path_1830" d="M967.689 330.09s.457 7.534-.685 8.675 4.338 3.2 4.338 3.2h5.023s0-10.045 1.141-11.871-9.817-.004-9.817-.004z" class="cls-7" data-name="Path 1830" transform="translate(-139.132 -42.979)"/>
+            <circle id="Ellipse_858" cx="4.673" cy="4.673" r="4.673" class="cls-9" data-name="Ellipse 858" transform="translate(829.279 265.287)"/>
+            <path id="Path_1831" d="M965.086 267.429a4.674 4.674 0 0 1 4.187-4.648 4.673 4.673 0 1 0 0 9.3 4.674 4.674 0 0 1-4.187-4.652z" class="cls-9" data-name="Path 1831" transform="translate(-137.365)"/>
+            <circle id="Ellipse_859" cx="8.447" cy="8.447" r="8.447" class="cls-8" data-name="Ellipse 859" transform="translate(824.79 274.441)"/>
+            <ellipse id="Ellipse_860" cx="7.789" cy="4.673" class="cls-9" data-name="Ellipse 860" rx="7.789" ry="4.673" transform="translate(825.384 273.465)"/>
+            <path id="Path_1832" d="M945.364 353.3s-6.392-4.794-7.762-3.881-11.415 4.794-12.328 9.36 11.643 25.57 11.643 25.57l14.839-1.6 4.566-5.022 1.142-5.479s.457-4.566 0-5.479-.457-11.644-1.37-11.872-5.022-2.968-5.479-2.283-5.251.686-5.251.686z" class="cls-4" data-name="Path 1832" transform="translate(-112.242 -55.919)"/>
+            <path id="Path_1833" d="M892.712 685.609s-4.109-.685-4.109 2.74-.457 14.383-.685 14.839-7.077 3.2-3.653 3.653a47.383 47.383 0 0 0 8.447 0l1.142-2.283 1.141 2.454 2.538.2s-.483-10.19.659-11.788-1.827-5.479-1.827-5.479.685-4.794.228-4.338-3.881.002-3.881.002z" class="cls-9" data-name="Path 1833" transform="translate(-85.159 -273.161)"/>
+            <path id="Path_1834" d="M1011.369 692.807s-2.055 7.306-1.6 8.219 0 3.881 0 3.881-1.826 6.37 2.283 6.826 5.479-1.575 5.479-2.031-.913-6.621-.913-7.762v-4.34l-.228-4.794z" class="cls-9" data-name="Path 1834" transform="translate(-166.603 -277.848)"/>
+            <path id="Path_1835" d="M925.918 434.731l-2.968 1.6s.228 5.023-1.141 7.077-5.936 42.236-6.392 42.236-2.283 5.936-3.424 7.306-9.36 25.113-6.849 27.4 19.862 6.393 21.917 4.795 9.589-60.5 9.589-60.5 2.739 61.184 6.164 60.956 20.547-2.968 20.547-4.794-7.534-81.96-18.264-87.9l-1.909-3.148a44.922 44.922 0 0 1-17.27 4.972z" class="cls-9" data-name="Path 1835" transform="translate(-98.959 -107.896)"/>
+            <path id="Path_1836" d="M915.077 372.078s-1.164.026-3.981.222-3.412-.372-5.5-1.67 4.026-8.329 4.026-8.329l7.367-1.014 2.248.4z" class="cls-5" data-name="Path 1836" transform="translate(-99.277 -63.659)"/>
+            <path id="Path_1837" d="M935.483 314.954l4.063-4.613s3.417-7.509 1.553-8.767-6.911 11.528-6.911 11.528z" class="cls-8" data-name="Path 1837" transform="translate(-118.031 -25.023)"/>
+            <path id="Path_1838" d="M904.084 349.837c-1.3-1.434.246-5.708.246-5.708l2.4-3.053 1.033-1.9s1.588-1.11.993-1.679 3.375-3.344 3.375-3.344l2.291-3.768 2.908 1.907a39.612 39.612 0 0 0-.916 5.17c.065.939-3.178 6.161-3.443 6.346s-.054 1.613-.4 2.248a10.613 10.613 0 0 0-.478 2.7s-6.709 2.515-8.009 1.081z" class="cls-4" data-name="Path 1838" transform="translate(-98.246 -43.691)"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Short description of what this resolves:

1) Adding [this image](https://app.zeplin.io/project/5bb1deae290afc111d140a3f/screen/5d12fb8adfb0cd644f7ad0f0
) from Zeplin to the directory
2) With the new logos provided by Milda, it's necessary to adpat the logo class, otherwise the logo container is not big enough to fit the text below it. Here it is the code for the new logo
```
<svg
    xmlns="http://www.w3.org/2000/svg"
    className="logo"
    aria-labelledby="logo__title plan"
    width="148"
    height="36"
>
    <g>
        <path d="M32.8 16.1c0 1.3-.3 2.3-1 2.8-.6.5-1.5.7-2.8.7h-2.1v-6.8H29c2.6 0 3.8 1.1 3.8 3.3zm1.3-4.5c-1.3-.9-3.1-1.4-5.4-1.4h-5.1V29h3.2v-6.7h1.9c2.3 0 4-.5 5.3-1.4 1.4-1.1 2.1-2.7 2.1-4.8.1-1.9-.6-3.5-2-4.5" />
        <path d="M44.8 14.1c-.9 0-1.7.3-2.3.8-.4.3-.8.8-1.1 1.3l-.2-1.8h-2.8v14.5h3.1v-8.4c.2-.8 1-3.4 2.9-3.4.4 0 .7.1 1.1.1l.4.1.6-3.1-.3-.1c-.4.1-.9 0-1.4 0" />
        <path d="M53.2 26.3c-2.2 0-3.2-1.6-3.2-4.9 0-1.7.3-3 .9-3.8.5-.8 1.3-1.1 2.4-1.1s1.8.4 2.3 1.1c.6.8.9 2.1.9 3.8-.1 3.3-1.1 4.9-3.3 4.9zm0-12.5c-2 0-3.7.8-4.8 2.1-1.1 1.3-1.7 3.2-1.7 5.5s.6 4.1 1.7 5.5c1.1 1.4 2.8 2.1 4.8 2.1s3.7-.8 4.8-2.1c1.1-1.3 1.7-3.2 1.7-5.5s-.6-4.1-1.7-5.5c-1.1-1.4-2.8-2.1-4.8-2.1" />
        <path d="M68.9 25.7c-.6.4-1.1.6-1.6.6-.8 0-1.3-.3-1.3-1.7v-7.9h3.1l.4-2.5h-3.6v-3.5l-3.1.3v3.1h-2.2v2.5h2.2v7.9c0 2.8 1.5 4.4 4.1 4.4 1.3 0 2.4-.4 3.3-1l.3-.2-1.3-2.3-.3.3" />
        <path d="M77.2 26.3c-2.2 0-3.2-1.6-3.2-4.9 0-1.7.3-3 .9-3.8.5-.8 1.3-1.1 2.4-1.1 1.1 0 1.8.4 2.3 1.1.6.8.9 2.1.9 3.8-.1 3.3-1.1 4.9-3.3 4.9zm0-12.5c-2 0-3.7.8-4.8 2.1-1.1 1.3-1.7 3.2-1.7 5.5s.6 4.1 1.7 5.5c1.1 1.4 2.8 2.1 4.8 2.1s3.7-.8 4.8-2.1c1.1-1.3 1.7-3.2 1.7-5.5s-.6-4.1-1.7-5.5c-1.1-1.4-2.8-2.1-4.8-2.1" />
        <path d="M93.6 14.1c-1.5 0-3 .6-4.1 1.7l-.1-1.4h-2.7v14.5h3.1V18.7c.5-.7 1.6-2 3.1-2 1.3 0 1.8.5 1.8 2v10.2h3.1V18.6c0-1.4-.3-2.5-.9-3.2-.8-.9-1.9-1.3-3.3-1.3" />
        <path d="M113.5 10.2l-3.6 12.5-3.8-12.5h-4L100.6 29h3.1l.7-9.6c.1-1.3.2-2.9.2-4.2l3.7 11.9h2.9l3.6-11.9c.1 1.2.1 2.7.3 4.2l.8 9.6h3.1l-1.6-18.8h-3.9" />
        <path d="M128.9 21.8v2.9c-.8 1.1-1.7 1.7-2.8 1.7-1.5 0-2.1-.7-2.1-2.2 0-.8.3-1.3.8-1.7.6-.4 1.6-.7 2.9-.7h1.2zm3.1 3.4v-6.5c0-2.2-.9-4.9-5.4-4.9-1.5 0-3.1.3-4.7.9l-.3.1.9 2.4.3-.1c1.3-.4 2.5-.7 3.5-.7 1.9 0 2.6.6 2.6 2.3v.7h-1.4c-2.2 0-3.8.4-5 1.2-1.2.8-1.8 2.1-1.8 3.6 0 2.8 1.9 4.6 4.8 4.6.9 0 1.7-.2 2.5-.5.6-.3 1.1-.6 1.6-1.1.5.9 1.4 1.5 2.6 1.6h.3l.8-2.3-.3-.1c-.7 0-1-.3-1-1.2" />
        <path d="M137.3 8c-.6 0-1.1.2-1.4.6s-.6.9-.6 1.4c0 1.2.9 2 2 2 .6 0 1.1-.2 1.5-.6.4-.4.6-.9.6-1.4-.1-1.2-.9-2-2.1-2" />
        <path d="M135.7 29h3.1V14.4h-3.1V29" />
        <path d="M147.2 26l-.3.1c-.2.1-.5.1-.8.1-.3 0-.5 0-.5-.8V8.2l-3.1.4v16.7c0 1.2.3 2.1.9 2.8.6.6 1.3.9 2.3.9.7 0 1.4-.2 2.1-.5l.3-.1-.9-2.4" />
    </g>
    <g>
        <path d="M8.3 25.4c-.4 0-1.1-.1-1.9-.7S0 20.1 0 20.1V28c0 .3 0 .9.9.9h14.9c.9 0 .9-.7.9-.9v-7.9s-5.6 4-6.4 4.6c-.9.6-1.6.7-2 .7z" />
        <path d="M8.3 5.6S0 5.4 0 13v5.1c0 .6.1.6 1.6 1.8 4.8 3.5 5.6 4.3 6.7 4.3s1.9-.8 6.7-4.3c1.6-1.1 1.6-1.2 1.6-1.8V13c.1-7.6-8.3-7.4-8.3-7.4zm4.8 10.7H3.6v-3.2c0-3.8 4.5-4 4.8-4 .3 0 4.8.2 4.8 4v3.2z" />
    </g>
    <title id="logo__title">ProtonMail</title>
    <text textAnchor="end" className="plan uppercase bold" x="147" y="42" id="plan" focusable="false">
       PLUS
    </text>
</svg>
```

## Changes proposed in this pull request:

- the new image is added to `assets/img/shared`
- change the `height` of the `.logo` class from 36px to 42px