### PR TITLE
Make dropdowns and tooltips the same z-index as modals

### DIFF
--- a/_sass/react-styles/_pm-dropdown.scss
+++ b/_sass/react-styles/_pm-dropdown.scss
@@ -4,7 +4,7 @@ $dropDown-narrow-width: 8em !default;
 
 .dropDown {
   position: fixed;
-  z-index: 10;
+  z-index: 667;
   display: block;
   opacity: 1;
   transition: visibility 0s ease, transform 0.15s ease, opacity 0.15s ease;

--- a/_sass/react-styles/_pm-tooltip.scss
+++ b/_sass/react-styles/_pm-tooltip.scss
@@ -4,7 +4,7 @@ $arrow-width: 0.5em;
 /* basic tooltip styles */
 .tooltip {
   position: fixed;
-  z-index: 666;
+  z-index: 667;
   width: $tooltip-width;
   border-radius: $global-border-radius;
   background: $pm-global-grey;


### PR DESCRIPTION
## Short description of what this resolves:

- Dropdowns not shown in modals in react projects.

## Changes proposed in this pull request:

- Makes z-index the same as modals for tooltips and dropdowns.

Fixes #
