### PR TITLE
Support new Dropdown styling properties & add new helpers.

### DIFF
--- a/_sass/react-styles/_pm-dropdown.scss
+++ b/_sass/react-styles/_pm-dropdown.scss
@@ -25,6 +25,10 @@ $dropDown-narrow-width: 8em !default;
   width: $dropDown-wide-width;
 }
 
+.dropDown--auto {
+  width: auto;
+}
+
 .dropDown--top {
   transform-origin: bottom center;
 }

--- a/_sass/reusable-components/_design-system-layout-modules.scss
+++ b/_sass/reusable-components/_design-system-layout-modules.scss
@@ -148,6 +148,26 @@ svg {
   margin-right: auto;
 }
 
+/* to absolute */
+.absolute {
+  position: absolute;
+  z-index: 1;
+}
+
+/* to centered absolute */
+.centered-absolute {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* to top right */
+.top-right {
+  top: 0;
+  right: 0;
+}
+
 /* hardware-acceleration activation */
 .hardware-accelerated {
   @include vendor-prefix(transform, translateZ(0));
@@ -279,6 +299,7 @@ $list-paddings-values: 0, 0.25, 0.5, 0.75, 1, 2 !default; // specify 2.5 if need
 .nonvisible { visibility: hidden; }
 
 .opacity-50 { opacity: .5; }
+.opacity-40 { opacity: .4; }
 .opacity-30 { opacity: .3; }
 
 .hidden, [hidden]  { display: none; } /* hidden everywhere */


### PR DESCRIPTION
## Short description of what this resolves:
* Adds ability for dropdown to have dynamic width.
* Adds .absolute helper that sets position of the element to `absolute`.
* Adds .centered-absolute helper that sets position of the element to `absolute` and centers it both vertically and horizontally.
* Adds .top-left helper, that positions absolute element in the top left of the container (useful for `close` icons)
* Adds .opacity-40 helper, as some elements in designs requires opacity of 40%.

Fixes https://github.com/ProtonMail/react-components/pull/193