### PR TITLE
Remove z-index from active group button

### DIFF
--- a/_sass/pm-styles/_pm-buttons.scss
+++ b/_sass/pm-styles/_pm-buttons.scss
@@ -296,7 +296,6 @@
 .pm-group-button:focus,
 .pm-group-button:active {
   position: relative;
-  z-index: 10;
 }
 .pm-group-buttons > .pm-group-button:first-child {
   border-radius: $global-border-radius 0 0 $global-border-radius;


### PR DESCRIPTION
No idea what this `z-index` is for @nico3333fr but it's causing problems, with other elements that should be on top most of the time (section titles for instance)

## Changes proposed in this pull request:

Removed, or at least `z-index` should be low, like 1.

Fixes ProtonMail/protonvpn-settings#69
