### PR TITLE
Added .rounded0 helpers

### DIFF
--- a/_sass/pm-styles/_pm-layout.scss
+++ b/_sass/pm-styles/_pm-layout.scss
@@ -11,6 +11,9 @@ hr {
 /* rounded corners */
 .rounded { border-radius: $global-border-radius; }
 .rounded50 { border-radius: 50%; }
+.rounded0 { border-radius: 0; }
+.rounded0-left { border-top-left-radius: 0; border-bottom-left-radius: 0; }
+.rounded0-right { border-top-right-radius: 0; border-bottom-right-radius: 0; }
 
 kbd {
   @extend .rounded;


### PR DESCRIPTION
## Short description of what this resolves:

Needed a helper to reset rounded corners.

## Changes proposed in this pull request:

- Added `.rounded0`, `.rounded0-left` and `rounded0-right` helpers.

Needed for https://github.com/ProtonMail/react-components/pull/254