### PR TITLE
Add more border and max width options

### DIFF
--- a/_sass/pm-styles/_pm-containers.scss
+++ b/_sass/pm-styles/_pm-containers.scss
@@ -26,6 +26,12 @@
 .border-top {
   border-top: 1px solid $pm-global-border;
 }
+.border-left {
+  border-left: 1px solid $pm-global-border;
+}
+.border-right {
+  border-right: 1px solid $pm-global-border;
+}
 
 .shadow-container {
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.16);

--- a/_sass/reusable-components/_design-system-layout-modules.scss
+++ b/_sass/reusable-components/_design-system-layout-modules.scss
@@ -297,7 +297,7 @@ $list-width-em: 400 !default;
 /* max-block widths */
 
 /* here you may add max-widths % */
-$list-max-widths: 80, 100 !default;
+$list-max-widths: 50, 80, 100 !default;
 @each $max-width in $list-max-widths {
   .mw#{$max-width} {
     max-width: #{$max-width * 1%};


### PR DESCRIPTION
## Short description of what this resolves:

Sometimes it is useful to combine borders for some custom use cases in admin panel: bot+left+right.

maxWidth 50% is useful for two sections side by side.  

## Changes proposed in this pull request:

- additional border helpers for more granularity
- mw50 helper.


