### PR TITLE
new css classes for responsive design in contacts

### DIFF
--- a/_sass/design-system-website/_global-structure.scss
+++ b/_sass/design-system-website/_global-structure.scss
@@ -80,7 +80,7 @@ body {
 
 
 .main-area,
-.main-area--withToolbar {
+.main-area--withToolbar{
   background: $white;
   color: $pm-global-grey;
   height: calc(100vh - #{$header-height} );
@@ -104,4 +104,16 @@ body {
 }
 .main-area--withToolbar.no-scroll {
   overflow: hidden;
+  height: calc(100vh - #{$toolbar-height} );
+  max-height: calc(100vh - #{$toolbar-height} );
+}
+.main-area--noHeader {
+  @extend .main-area;
+  height: calc(100vh);
+  max-height: calc(100vh);
+}
+.main-area--withToolbar--noHeader {
+  @extend .main-area--withToolbar;
+  height: calc(100vh - #{$toolbar-height} );
+  max-height: calc(100vh - #{$toolbar-height} );
 }

--- a/_sass/pm-styles/_pm-conversations.scss
+++ b/_sass/pm-styles/_pm-conversations.scss
@@ -6,6 +6,10 @@
   width: calc( (100% + var(--width-sidebar, #{$width-sidebar}) ) * #{$conversations-column-width/1%/100} );
   border-right: 1px solid $pm-global-border;
 }
+.items-column-list--mobile {
+  @extend .items-column-list;
+  width: calc( (100% + var(--width-sidebar, #{$width-sidebar}) ) );
+}
 
 .items-column-list,
 .view-column-detail {

--- a/_sass/pm-styles/_pm-conversations.scss
+++ b/_sass/pm-styles/_pm-conversations.scss
@@ -7,8 +7,7 @@
   border-right: 1px solid $pm-global-border;
 }
 .items-column-list--mobile {
-  @extend .items-column-list;
-  width: calc( (100% + var(--width-sidebar, #{$width-sidebar}) ) );
+  width: 100%;
 }
 
 .items-column-list,


### PR DESCRIPTION
## Short description of what this resolves:

For the new responsive design in `contacts` (https://github.com/ProtonMail/proton-contacts/issues/225), we need new CSS classes

## Changes proposed in this pull request:

- add `main-area--noHeader` class
- add `main-area--withToolbar--noHeader` class
- add `items-column-list--mobile` class
