### PR TITLE
Fix main-area-withToolbar CSS class

### DIFF
--- a/_sass/design-system-website/_global-structure.scss
+++ b/_sass/design-system-website/_global-structure.scss
@@ -79,21 +79,25 @@ body {
 }
 
 
-.main-area,
-.main-area--withToolbar{
+.main-area {
   background: $white;
   color: $pm-global-grey;
-  height: calc(100vh - #{$header-height} - #{$toolbar-height} );
-  max-height: calc(100vh - #{$header-height} - #{$toolbar-height} );
+  height: calc(100vh - #{$header-height} );
+  max-height: calc(100vh - #{$header-height} );
   overflow: auto;
+  border-radius: 4px 4px 0 0;
   
   &.no-scroll {
     overflow: hidden;
   }
 }
-.main-area {
-  border-radius: 4px 4px 0 0;
+.main-area--withToolbar {
+  @extend .main-area;
+  height: calc(100vh - #{$header-height} - #{$toolbar-height} );
+  max-height: calc(100vh - #{$header-height} - #{$toolbar-height} );
+  border-radius: 0;
 }
+
 .main-full {
   height: 100vh;
   overflow: auto;

--- a/_sass/design-system-website/_global-structure.scss
+++ b/_sass/design-system-website/_global-structure.scss
@@ -83,7 +83,8 @@ body {
 .main-area--withToolbar{
   background: $white;
   color: $pm-global-grey;
-  height: calc(100vh - #{$header-height} );
+  height: calc(100vh - #{$header-height} - #{$toolbar-height} );
+  max-height: calc(100vh - #{$header-height} - #{$toolbar-height} );
   overflow: auto;
   
   &.no-scroll {
@@ -93,17 +94,10 @@ body {
 .main-area {
   border-radius: 4px 4px 0 0;
 }
-.main-area--withToolbar {
-  height: calc(100vh - #{$header-height} - #{$toolbar-height} );
-  max-height: calc(100vh - #{$header-height} - #{$toolbar-height} );
-}
 .main-full {
   height: 100vh;
   overflow: auto;
   @extend .bg-global-altgrey-gradient;
-}
-.main-area--withToolbar.no-scroll {
-  overflow: hidden;
 }
 .main-area--noHeader {
   @extend .main-area;

--- a/_sass/design-system-website/_global-structure.scss
+++ b/_sass/design-system-website/_global-structure.scss
@@ -104,8 +104,6 @@ body {
 }
 .main-area--withToolbar.no-scroll {
   overflow: hidden;
-  height: calc(100vh - #{$toolbar-height} );
-  max-height: calc(100vh - #{$toolbar-height} );
 }
 .main-area--noHeader {
   @extend .main-area;


### PR DESCRIPTION
I think there were a few typos in the `main-area-withToolbar` class, like redundant definitions and extra unneeded definitions.

I did some checks in `contacts` and `settings` to see that the proposed changes do not break the layout, and it seems fine