### PR TITLE
fix mismatch between html and what is displayed

### DIFF
--- a/flexbox-helpers.html
+++ b/flexbox-helpers.html
@@ -228,9 +228,9 @@ section: fe-guidelines
   </div>
   <div class="w49 aligncenter flex-self-vcenter">
     <pre class=" language-markup"><code>&lt;div <strong>class="flex "</strong>&gt;
-  &lt;div class="w150p"&gt;div&lt;/div&gt;
-  &lt;span class="w25"&gt;span&lt;/span&gt;
-  &lt;em class="flex-item-fluid"&gt;em&lt;/em&gt;
+  &lt;div class="w150p"&gt;.w150p&lt;/div&gt;
+  &lt;span class="w25"&gt;.w25&lt;/span&gt;
+  &lt;em class="flex-item-fluid"&gt;.flex-item-fluid&lt;/em&gt;
 &lt;/div&gt;
 </code></pre>
   </div>


### PR DESCRIPTION
## Short description of what this resolves:

In the "Flexbox helpers" section of the web, there was a mismatch between the html code proposed and the one displayed:

![image](https://user-images.githubusercontent.com/33841139/69915890-715dc300-1454-11ea-899d-984c28d42bcc.png)

## Changes proposed in this pull request:

- Resolve the mismatch