### PR TITLE
Fix/disabled buttons dark mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 - removed `bg-global-light` class in table examples for `pm-plans-table-row--highlighted` (more darkmode-friendly)
 - updated Calendar/Contacts icon
 - fixed mini-calendar range display in responsive view
+- fixed disabled buttons
 
 
 # [1.7.7] - 2019-11-21

--- a/_sass/pm-styles/_pm-buttons-mixins.scss
+++ b/_sass/pm-styles/_pm-buttons-mixins.scss
@@ -3,12 +3,26 @@
 
 
 @mixin button-disabled-state-dm {
-  opacity: .6;
+  //opacity: .6;
   background-color: $pm-global-grey;
-  color: rgba( $pm-global-muted, .6 );
-  border-color: rgba( $pm-global-muted, .6 );
+  color: rgba( $pm-global-muted, .3 );
   pointer-events: none;
+  border-color: rgba( $pm-global-muted, .3 );
+  & svg { 
+    fill: rgba( $pm-global-muted, .3 );
+  }
 }
+
+// @mixin button-disabled-state-dm {
+//   //opacity: .6;
+//   background-color: $pm-global-grey;
+//   color: rgba( $pm-global-muted, .6 );
+//   pointer-events: none;
+//   border-color: rgba( $pm-global-muted, .6 );
+//   & svg { 
+//     fill: rgba( $pm-global-muted, .6 );
+//   }
+// }
 
 @mixin pm-button-dark {
   color: $white;

--- a/_sass/pm-styles/_pm-buttons-mixins.scss
+++ b/_sass/pm-styles/_pm-buttons-mixins.scss
@@ -2,8 +2,14 @@
 @import "../reusable-components/design-system-config";
 
 
-@mixin button-disabled-state-dm {
-  //opacity: .6;
+@mixin button-disabled-state (){
+  background-color: $pm-global-muted;
+  color: rgba( $pm-global-grey, .3 );
+    border-color: $pm-global-border;
+  pointer-events: none;
+}
+
+@mixin button-disabled-state-dm() {
   background-color: $pm-global-grey;
   color: rgba( $pm-global-muted, .3 );
   pointer-events: none;
@@ -12,17 +18,6 @@
     fill: rgba( $pm-global-muted, .3 );
   }
 }
-
-// @mixin button-disabled-state-dm {
-//   //opacity: .6;
-//   background-color: $pm-global-grey;
-//   color: rgba( $pm-global-muted, .6 );
-//   pointer-events: none;
-//   border-color: rgba( $pm-global-muted, .6 );
-//   & svg { 
-//     fill: rgba( $pm-global-muted, .6 );
-//   }
-// }
 
 @mixin pm-button-dark {
   color: $white;

--- a/_sass/pm-styles/_pm-buttons.scss
+++ b/_sass/pm-styles/_pm-buttons.scss
@@ -42,9 +42,7 @@
   }
   &[disabled],
   &.is-disabled {
-    background-color: $pm-global-muted;
-    color: rgba( $pm-global-grey, .3 );
-    pointer-events: none;
+    @include button-disabled-state;
   }
   /* just to cancel examples  */
   &.is-active:hover {
@@ -87,10 +85,7 @@
   }
   &[disabled],
   &.is-disabled {
-    background-color: $pm-global-muted;
-    color: rgba( $pm-global-grey, .3 );
-    border-color: $pm-global-border;
-    pointer-events: none;
+    @include button-disabled-state;
   }
   /* just to cancel examples  */
   &.is-hover:hover {
@@ -120,10 +115,7 @@
   }
   &[disabled],
   &.is-disabled {
-    background-color: $pm-global-muted;
-    color: rgba( $pm-global-grey, .3 );
-    border-color: $pm-global-border;
-    pointer-events: none;
+    @include button-disabled-state;
   }
 }
 
@@ -154,10 +146,7 @@
   }
   &[disabled],
   &.is-disabled {
-    background-color: $pm-global-muted;
-    color: rgba( $pm-global-grey, .3 );
-    border-color: $pm-global-border;
-    pointer-events: none;
+    @include button-disabled-state;
   }
   /* just to cancel examples  */
   &.is-hover:hover {
@@ -187,10 +176,7 @@
   }
   &[disabled],
   &.is-disabled {
-    background-color: $pm-global-muted;
-    color: rgba( $pm-global-grey, .3 );
-    border: 1px solid $pm-global-border;
-    pointer-events: none;
+    @include button-disabled-state;
   }
 }
 
@@ -257,6 +243,23 @@
     }
   }
 }
+
+/* exception for group buttons, disabled state should keep the border */
+.pm-group-button {
+  &[disabled],
+  &.is-disabled {
+    &.pm-button {
+      border-color: $pm-global-border;
+    }
+    &.pm-button-blueborder {
+      border-color: $pm-primary;
+    }
+    &.pv-button-greenborder {
+      border-color: $pv-green;
+    }
+  }
+}
+
 
 /* aliases for buttons => different per project */
 /* primary/link/error/warning/info */

--- a/_sass/pm-styles/_pm-buttons.scss
+++ b/_sass/pm-styles/_pm-buttons.scss
@@ -340,7 +340,6 @@
   border-color: $pm-global-warning;
   color: $pm-global-warning;
 }
-
 .pm-button--whiteborder {
   border: 1px solid $white;
 }
@@ -349,8 +348,6 @@
 .pm-button--noborder {
   border: 0;
 }
-
-
 .pm-button--currentColor {
   color: currentColor;
 }

--- a/_sass/pm-styles/_pm-dark-theme.scss
+++ b/_sass/pm-styles/_pm-dark-theme.scss
@@ -15,13 +15,16 @@
   @include pv-button-greenborder-dark;
 }
 
+// standalone button
 .pm-button-blue,
 .pm-button.pm-button-blue,
 .pv-button-green,
 .pm-button.pv-button-green {
   &[disabled],
   &.is-disabled {
+  &:not(.pm-group-button) {
     @include button-disabled-state-dm;
+  }
   }
 }
 

--- a/_sass/pm-styles/_pm-dark-theme.scss
+++ b/_sass/pm-styles/_pm-dark-theme.scss
@@ -22,9 +22,7 @@
 .pm-button.pv-button-green {
   &[disabled],
   &.is-disabled {
-  &:not(.pm-group-button) {
     @include button-disabled-state-dm;
-  }
   }
 }
 
@@ -40,6 +38,21 @@ a, .link,
   &[disabled],
   &.is-disabled {
     color:  rgba( $white, .5 );
+  }
+}
+
+.pm-group-button {
+  &[disabled],
+  &.is-disabled {
+    &.pm-button {
+      border-color: var(--bordercolor-input, $pm-global-border);
+    }
+    &.pm-button-blueborder {
+      border-color: $pm-primary-light;
+    }
+    &.pv-button-greenborder {
+      border-color: $pv-green-light;
+    }
   }
 }
 

--- a/buttons.html
+++ b/buttons.html
@@ -338,7 +338,7 @@ subsection: buttons
   &lt;button class="<strong>pm-group-button</strong>"&gt;button&lt;/button&gt;
   &lt;button class="<strong>pm-group-button</strong>"&gt;button&lt;/button&gt;
   &lt;button class="<strong>pm-group-button</strong>"&gt;button&lt;/button&gt;
-  &lt;button class="<strong>pm-group-button</strong>"&gt;button&lt;/button&gt;
+  &lt;button class="<strong>pm-group-button</strong>" disabled&gt;button&lt;/button&gt;
 &lt;/div&gt;</code></pre>
 
 <p>This will only add the “behaviour” for group, not the design. Examples, to achieve this: </p>
@@ -354,7 +354,7 @@ subsection: buttons
   &lt;button class="<strong>pm-group-button pm-button-blueborder</strong>"&gt;button&lt;/button&gt;
   &lt;button class="<strong>pm-group-button pm-button-blueborder</strong>"&gt;button&lt;/button&gt;
   &lt;button class="<strong>pm-group-button pm-button-blueborder</strong>"&gt;button&lt;/button&gt;
-  &lt;button class="<strong>pm-group-button pm-button-blueborder</strong>"&gt;button&lt;/button&gt;
+  &lt;button class="<strong>pm-group-button pm-button-blueborder</strong>" disabled&gt;button&lt;/button&gt;
 &lt;/div&gt;</code></pre>
 
 <h3 class="mt1">States classes</h3>
@@ -372,7 +372,23 @@ subsection: buttons
   &lt;button class="pm-group-button pv-button-greenborder"&gt;button&lt;/button&gt;
   &lt;button class="pm-group-button pv-button-greenborder <strong>is-active</strong>"&gt;button&lt;/button&gt;
   &lt;button class="pm-group-button pv-button-greenborder"&gt;button&lt;/button&gt;
-  &lt;button class="pm-group-button pv-button-greenborder"&gt;button&lt;/button&gt;
+  &lt;button class="pm-group-button pv-button-greenborder" disabled&gt;button&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+
+<h3 class="mt1">Aliases</h3>
+
+<div class="pm-group-buttons mb1">
+    <button class="pm-group-button pm-button--primaryborder">button</button>
+    <button class="pm-group-button pm-button--primaryborder">button</button>
+    <button class="pm-group-button pm-button--primaryborder">button</button>
+    <button class="pm-group-button pm-button--primaryborder" disabled>button</button>
+</div>
+
+<pre class=" language-markup"><code>&lt;div class="<strong>pm-group-buttons</strong>"&gt;
+  &lt;button class="<strong>pm-group-button pm-button--primaryborder</strong>"&gt;button&lt;/button&gt;
+  &lt;button class="<strong>pm-group-button pm-button--primaryborder</strong>"&gt;button&lt;/button&gt;
+  &lt;button class="<strong>pm-group-button pm-button--primaryborder</strong>"&gt;button&lt;/button&gt;
+  &lt;button class="<strong>pm-group-button pm-button--primaryborder</strong> disabled"&gt;button&lt;/button&gt;
 &lt;/div&gt;</code></pre>
 
 <h3 class="mt1">Aligning buttons near button groups</h3>

--- a/buttons.html
+++ b/buttons.html
@@ -327,6 +327,13 @@ subsection: buttons
     Add <code>pm-group-buttons</code> on the container and <code>pm-group-button</code> to each button:
 </p>
 
+<div class="pm-group-buttons mb1">
+    <button class="pm-group-button pm-button">button</button>
+    <button class="pm-group-button pm-button">button</button>
+    <button class="pm-group-button pm-button">button</button>
+    <button class="pm-group-button pm-button" disabled>button</button>
+</div>
+
 <pre class=" language-markup"><code>&lt;div class="<strong>pm-group-buttons</strong>"&gt;
   &lt;button class="<strong>pm-group-button</strong>"&gt;button&lt;/button&gt;
   &lt;button class="<strong>pm-group-button</strong>"&gt;button&lt;/button&gt;
@@ -340,7 +347,7 @@ subsection: buttons
     <button class="pm-group-button pm-button-blueborder">button</button>
     <button class="pm-group-button pm-button-blueborder">button</button>
     <button class="pm-group-button pm-button-blueborder">button</button>
-    <button class="pm-group-button pm-button-blueborder">button</button>
+    <button class="pm-group-button pm-button-blueborder" disabled>button</button>
 </div>
 
 <pre class=" language-markup"><code>&lt;div class="<strong>pm-group-buttons</strong>"&gt;
@@ -358,7 +365,7 @@ subsection: buttons
     <button class="pm-group-button pv-button-greenborder">button</button>
     <button class="pm-group-button pv-button-greenborder is-active">button</button>
     <button class="pm-group-button pv-button-greenborder">button</button>
-    <button class="pm-group-button pv-button-greenborder">button</button>
+    <button class="pm-group-button pv-button-greenborder" disabled>button</button>
 </div>
 
 <pre class=" language-markup"><code>&lt;div class="pm-group-buttons"&gt;
@@ -398,7 +405,7 @@ subsection: buttons
         <use xlink:href="#shape-label"></use>
       </svg>
     </button>
-    <button class="pm-group-button pm-button pm-button--for-icon pm-group-button">
+    <button class="pm-group-button pm-button pm-button--for-icon pm-group-button" disabled>
       <svg viewBox="0 0 16 16" class="icon-16p fill-global-grey mtauto mbauto" role="img" aria-hidden="true" focusable="false">
         <use xlink:href="#shape-caret"></use>
       </svg>


### PR DESCRIPTION
## Short description of what this resolves:

Some issues in button groups (for disabled states) and inconsistencies (disabled buttons should NOT be more visible than active ones ^^)

## Changes proposed in this pull request:

- revamped disabled buttons
- added a mixin for disabled design for "standalone" buttons => one design for all
- added exceptions for button groups (to keep the border of the group)
- added some tests

![image](https://user-images.githubusercontent.com/2578321/71245152-69d36080-2314-11ea-9703-5734a895fe66.png)

![image](https://user-images.githubusercontent.com/2578321/71245179-75268c00-2314-11ea-9f72-af586ddaf459.png)
